### PR TITLE
Remove urllib.parse.unquote usage

### DIFF
--- a/run.py
+++ b/run.py
@@ -4,7 +4,6 @@ import hashlib
 import logging
 import math
 import os
-import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock
 
@@ -247,14 +246,14 @@ class GoFile(metaclass=GoFileMeta):
                                 filename = child["name"]
                                 if not any(fnmatch.fnmatch(filename, pattern) for pattern in excludes):
                                     files.append(File(
-                                        link=urllib.parse.unquote(child["link"]), 
-                                        dest=urllib.parse.unquote(os.path.join(dir, sanitize_filename(filename)))))
+                                        link=child["link"],
+                                        dest=os.path.join(dir, sanitize_filename(filename))))
                     else:
                         filename = data["data"]["name"]
                         if not any(fnmatch.fnmatch(filename, pattern) for pattern in excludes):
                             files.append(File(
-                                link=urllib.parse.unquote(data["data"]["link"]), 
-                                dest=urllib.parse.unquote(os.path.join(dir, sanitize_filename(filename)))))
+                                link=data["data"]["link"],
+                                dest=os.path.join(dir, sanitize_filename(filename))))
                 else:
                     logger.error(f"invalid password: {data['data'].get('passwordStatus')}")
         elif url is not None:


### PR DESCRIPTION
Using this function seems unnecessary and is even problematic in the link case.

The directory name (`data["data"]["name"]`) is never url encoded, so attempting to url decode is either useless or harmful if the folder name happens to match an escape sequence accidentally.

Url decoding the link is problematic if the link contains a quoted `#` (`%23`), because unquoting it returns it to a `#` which will not be re-encoded by the `requests.get` call as it is interpreted as a hash mark instead. Removing the unquote call fixes all downloads of files that contain a `#` in their file name.